### PR TITLE
Feature: [step2-2] Stateless 애플리케이션 배포

### DIFF
--- a/k8s/step2-2/frontend.yaml
+++ b/k8s/step2-2/frontend.yaml
@@ -1,0 +1,37 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: frontend
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+        app: guestbook
+        tier: frontend
+  template:
+    metadata:
+      labels:
+        app: guestbook
+        tier: frontend
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: topology.kubernetes.io/zone
+                operator: In
+                values:
+                - ap-northeast-2a
+      containers:
+      - name: php-redis
+        image: gcr.io/google_samples/gb-frontend:v5
+        env:
+        - name: GET_HOSTS_FROM
+          value: "dns"
+        resources:
+          requests:
+            cpu: 100m
+            memory: 100Mi
+        ports:
+        - containerPort: 80

--- a/k8s/step2-2/frontend.yaml
+++ b/k8s/step2-2/frontend.yaml
@@ -1,3 +1,24 @@
+# SOURCE: https://cloud.google.com/kubernetes-engine/docs/tutorials/guestbook
+apiVersion: v1
+kind: Service
+metadata:
+  name: frontend
+  labels:
+    app: guestbook
+    tier: frontend
+spec:
+  # if your cluster supports it, uncomment the following to automatically create
+  # an external load-balanced IP for the frontend service.
+  # type: LoadBalancer
+  #type: LoadBalancer
+  ports:
+    # the port that this service should serve on
+  - port: 80
+  selector:
+    app: guestbook
+    tier: frontend
+  type: LoadBalancer
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/k8s/step2-2/redis-follower.yaml
+++ b/k8s/step2-2/redis-follower.yaml
@@ -1,0 +1,29 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redis-follower
+  labels:
+    app: redis
+    role: follower
+    tier: backend
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: redis
+  template:
+    metadata:
+      labels:
+        app: redis
+        role: follower
+        tier: backend
+    spec:
+      containers:
+      - name: follower
+        image: gcr.io/google_samples/gb-redis-follower:v2
+        resources:
+          requests:
+            cpu: 100m
+            memory: 100Mi
+        ports:
+        - containerPort: 6379

--- a/k8s/step2-2/redis-follower.yaml
+++ b/k8s/step2-2/redis-follower.yaml
@@ -1,3 +1,21 @@
+# SOURCE: https://cloud.google.com/kubernetes-engine/docs/tutorials/guestbook
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis-follower
+  labels:
+    app: redis
+    role: follower
+    tier: backend
+spec:
+  ports:
+    # the port that this service should serve on
+  - port: 6379
+  selector:
+    app: redis
+    role: follower
+    tier: backend
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/k8s/step2-2/redis-leader.yaml
+++ b/k8s/step2-2/redis-leader.yaml
@@ -1,0 +1,29 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redis-leader
+  labels:
+    app: redis
+    role: leader
+    tier: backend
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: redis
+  template:
+    metadata:
+      labels:
+        app: redis
+        role: leader
+        tier: backend
+    spec:
+      containers:
+      - name: leader
+        image: "docker.io/redis:6.0.5"
+        resources:
+          requests:
+            cpu: 100m
+            memory: 100Mi
+        ports:
+        - containerPort: 6379

--- a/k8s/step2-2/redis-leader.yaml
+++ b/k8s/step2-2/redis-leader.yaml
@@ -1,3 +1,21 @@
+# SOURCE: https://cloud.google.com/kubernetes-engine/docs/tutorials/guestbook
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis-leader
+  labels:
+    app: redis
+    role: leader
+    tier: backend
+spec:
+  ports:
+  - port: 6379
+    targetPort: 6379
+  selector:
+    app: redis
+    role: leader
+    tier: backend
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:


### PR DESCRIPTION
Step 2-1에서는 [Stateless 애플리케이션을 배포](https://kubernetes.io/ko/docs/tutorials/stateless-application/)하여 아래의 작업들을 수행합니다.
* 디플로이먼트로 배포
    * Scale Up & Down 
    * [NodeAffinity](https://kubernetes.io/ko/docs/concepts/scheduling-eviction/assign-pod-node/)를 사용해 특정 노드에 고정하여 애플리케이션을 배포
* NodePort, Port-forward 등으로 애플리케이션을 노출하여 접근
* Recreate, RollingUpdate의 동작 방식을 이해하고 BlueGreen 배포 구현
* Load Balancer 생성

쿠버네티스에서는 [HPA](https://kubernetes.io/ko/docs/tasks/run-application/horizontal-pod-autoscale/)를 통해 리소스(Deployment, StatefulSet 등)를 자동으로 업데이트하여
워크로드의 크기를 수요에 맞게 자동으로 스케일링합니다.

노드 어피니티는 개념적으로 <code>nodeSelector</code>와 비슷하며, 노드의 레이블을 기반으로 파드가 스케쥴링될 수 있는 노드를 제한할 수 있습니다. 
아래의 명령어를 통해서 노드의 레이블을 확인합니다.
```
kubectl get nodes --show-labels
```
확인한 노드의 레이블 중 각 노드를 구분할 수 있는 레이블을 파드 스펙의 <code>.spec.affinity.nodeAffinity</code> 필드에 
노드 어피니티를 명시하여 특정 노드에 고정적으로 애플리케이션을 배포할 수 있습니다.

파드의 Recreate의 경우 파드의 스펙에 <code>.spec.strategy.type==Recreate</code>이면 새 파드가 생성되기 전에 파드가 죽습니다.
그리고 RollingUpdate를 사용하면 파드의 인스턴스를 새 인스턴스로 점진적으로 업데이트하여 가동 중지 시간 없이 배포 업데이트를 수행할 수 있습니다.
롤링 업데이트 실습의 경우의 [롤링 업데이트 수행](https://kubernetes.io/docs/tutorials/kubernetes-basics/update/update-intro/) 예제를 참고하여 수행하였습니다.


Ref
* [연습예제: HorizontalPodAutoscaler 연습](https://kubernetes.io/ko/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough/)
* [노드에 파드 할당하기](https://kubernetes.io/ko/docs/concepts/scheduling-eviction/assign-pod-node/)
* [노드 어피니티를 사용해 노드에 파드 할당](https://kubernetes.io/ko/docs/tasks/configure-pod-container/assign-pods-nodes-using-node-affinity/)
* [디플로이먼트 재생성](https://kubernetes.io/ko/docs/concepts/workloads/controllers/deployment/)
* [롤링 업데이트 수행하기](https://kubernetes.io/ko/docs/tutorials/kubernetes-basics/update/update-intro/)