### PR TITLE
Feature: [step3] StatefulSet으로 MySQL App 배포

### DIFF
--- a/k8s/step3/mysql.yaml
+++ b/k8s/step3/mysql.yaml
@@ -5,3 +5,16 @@ metadata:
   name: mysql-secret
 data:
   DB_Password: test1234
+--- 
+apiVersion: v1
+kind: Service
+metadata:
+  name: mysql-headless
+  labels:
+    app: mysql
+spec:
+  ports:
+  - port: 3306
+  clusterIP: None
+  selector:
+    app: mysql

--- a/k8s/step3/mysql.yaml
+++ b/k8s/step3/mysql.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  creationTimestamp: null
+  name: mysql-secret
+data:
+  DB_Password: test1234

--- a/k8s/step3/mysql.yaml
+++ b/k8s/step3/mysql.yaml
@@ -18,3 +18,55 @@ spec:
   clusterIP: None
   selector:
     app: mysql
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: mysql-app
+spec:
+  selector:
+    matchLabels:
+      app: mysql 
+  serviceName: "mysql-headless"
+  replicas: 2
+  minReadySeconds: 10
+  template:
+    metadata:
+      labels:
+        app: mysql 
+    spec:
+      terminationGracePeriodSeconds: 10
+      containers:
+      - name: mysql
+        image: mysql:5.6
+        env:
+        - name: MYSQL_ROOT_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: mysql-secret
+              key: DB_Password
+        ports:
+        - containerPort: 3306
+          name: mysql
+        volumeMounts:
+        - name: mps
+          mountPath: /usr/share/mysql/html
+        resources:
+          requests:
+            cpu: 1
+            memory: 2Gi
+        livenessProbe:
+          exec:
+            command: ["mysqladmin", "-uroot", "-p$MYSQL_ROOT_PASSWORD", "ping"]
+          initialDelaySeconds: 30
+          periodSeconds: 10
+          timeoutSeconds: 5
+  volumeClaimTemplates:
+  - metadata:
+      name: mps
+    spec:
+      accessModes: [ "ReadWriteOnce" ]
+      storageClassName: gp2
+      resources:
+        requests:
+          storage: 1Gi


### PR DESCRIPTION
Step 3에서는 MySQL App을 StatefulSet으로 배포해봅니다.
MySQL App의 구성 조건은 아래와 같습니다.
* StatefulSet으로 배포
* Replicas는 2 이상의 정의
* Resources, LivenessProbe를 정의
* Secret을 생성하여 Root 패스워드 설정
* PVC를 이용하여 스토리지와 연결
* Headless Service를 생성하여 MySQL App과 연결

MySQL App의 LivenessProbe의 경우 다른 Stateless 애플리케이션과 다르게 HTTP 요청을 통해서 확인하기 힘들기 때문에
MySQL에 접속할 수 있는지를 확인하여 LivenessProbe Check를 수행하였습니다.

Secret에 패스워드를 정의하여 중요한 정보인 패스워드를 파드 명세나 컨테이너 이미지에 포함되지 않도록 하였습니다.
즉, Kubernetes의 Secret을 사용하면 사용자의 비밀 데이터를 애플리케이션 코드에 넣을 필요가 없습니다.

세미 프로젝트의 경우 [Step1](https://github.com/moonstar0331/eks-semi-project/pull/2)에서 진행한 [CSI 드라이버](https://github.com/container-storage-interface/spec/blob/master/spec.md) 설치와 [OICD 공급자 생성](https://docs.aws.amazon.com/ko_kr/eks/latest/userguide/enable-iam-roles-for-service-accounts.html)를 수행하여
Step3에서는 별도의 조치없이 PVC를 이용하여 스토리지를 동적 프로비저닝 할 수 있습니다.

Ref
* [Kubernetes StatefulSet](https://kubernetes.io/ko/docs/concepts/workloads/controllers/statefulset/)
* [Kubernetes Secret](https://kubernetes.io/ko/docs/concepts/configuration/secret/)